### PR TITLE
Observation extended to 1800 and switched to binary search in _getSurroundingObservations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
+- `observations` extends to `1800` at `CumulativeTwap.sol` to support extreme circumstance.
+- To better enhance above performance, we introduce binary search mimicked from https://github.com/Uniswap/v3-core/blob/05c10bf/contracts/libraries/Oracle.sol#L153.
+- Remove `CT_NEH` from `CumulativeTwap.sol`. Won't be calculated if so. Simply return latest price at `CachedTwap.sol`.
+- Fix imprecise TWAP calculation when historical data is not enough at `CumulativeTwap.sol`. Won't be calculated if so.
+
 
 ## [0.6.1] - TBD
 - Fix cachedTwap won't be updated when latest updated timestamp not changed

--- a/contracts/twap/CumulativeTwap.sol
+++ b/contracts/twap/CumulativeTwap.sol
@@ -134,9 +134,6 @@ contract CumulativeTwap is BlockContext {
         return timestampDiff == 0 ? 0 : currentCumulativePrice.sub(targetCumulativePrice).div(timestampDiff);
     }
 
-    // targetTimestamp = "uniswap's uint32 target = time - secondsAgo"
-    // _blockTimestamp = time
-    // secondsAgo = interval
     function _getSurroundingObservations(uint256 targetTimestamp)
         internal
         view

--- a/contracts/twap/CumulativeTwap.sol
+++ b/contracts/twap/CumulativeTwap.sol
@@ -169,8 +169,8 @@ contract CumulativeTwap is BlockContext {
         }
 
         // now, set before to the oldest observation
-        beforeOrAt = observations[currentObservationIndex + 1];
-        if (observations[currentObservationIndex].timestamp == 0) {
+        beforeOrAt = observations[(currentObservationIndex + 1) % MAX_OBSERVATION];
+        if (beforeOrAt.timestamp == 0) {
             beforeOrAt = observations[0];
         }
 

--- a/contracts/twap/CumulativeTwap.sol
+++ b/contracts/twap/CumulativeTwap.sol
@@ -123,6 +123,10 @@ contract CumulativeTwap is BlockContext {
         else if (atOrAfter.timestamp == targetTimestamp) {
             targetCumulativePrice = atOrAfter.priceCumulative;
         }
+        // not enough historical data
+        else if (beforeOrAt.timestamp == atOrAfter.timestamp) {
+            return 0;
+        }
         // case3. in the middle
         else {
             // atOrAfter.timestamp == 0 implies beforeOrAt = observations[currentObservationIndex]
@@ -159,6 +163,7 @@ contract CumulativeTwap is BlockContext {
             // if the observation is the same as the targetTimestamp
             // atOrAfter doesn't matter
             // if the observation is less than the targetTimestamp
+            // simply return empty atOrAfter
             // atOrAfter repesents latest price and timestamp
             return (beforeOrAt, atOrAfter);
         }
@@ -170,8 +175,10 @@ contract CumulativeTwap is BlockContext {
         }
 
         // ensure that the target is chronologically at or after the oldest observation
-        // CT_NEH: no enough historical data
-        require(beforeOrAt.timestamp <= targetTimestamp, "CT_NEH");
+        // if no enough historical data, simply return two beforeOrAt and return 0 at _calculateTwap
+        if (beforeOrAt.timestamp > targetTimestamp) {
+            return (beforeOrAt, beforeOrAt);
+        }
 
         return _binarySearch(targetTimestamp);
     }

--- a/contracts/twap/CumulativeTwap.sol
+++ b/contracts/twap/CumulativeTwap.sol
@@ -25,7 +25,7 @@ contract CumulativeTwap is BlockContext {
     uint16 internal constant MAX_OBSERVATION = 1800;
     // let's use 15 mins and 1 hr twap as example
     // if the price is updated every 2 secs, 1hr twap Observation should have 60 / 2 * 60 = 1800 slots
-    Observation[MAX_OBSERVATION + 1] public observations;
+    Observation[MAX_OBSERVATION] public observations;
 
     //
     // INTERNAL

--- a/contracts/twap/CumulativeTwap.sol
+++ b/contracts/twap/CumulativeTwap.sol
@@ -155,10 +155,10 @@ contract CumulativeTwap is BlockContext {
         // CT_NEH: no enough historical data
         require(beforeOrAt.timestamp <= targetTimestamp, "CT_NEH");
 
-        return binarySearch(targetTimestamp);
+        return _binarySearch(targetTimestamp);
     }
 
-    function binarySearch(uint256 targetTimestamp)
+    function _binarySearch(uint256 targetTimestamp)
         private
         view
         returns (Observation memory beforeOrAt, Observation memory atOrAfter)

--- a/contracts/twap/CumulativeTwap.sol
+++ b/contracts/twap/CumulativeTwap.sol
@@ -22,10 +22,10 @@ contract CumulativeTwap is BlockContext {
     //
 
     uint16 public currentObservationIndex;
-    uint16 internal constant UINT16_MAX = 65535;
+    uint16 internal constant MAX_OBSERVATION = 1800;
     // let's use 15 mins and 1 hr twap as example
-    // if the price is updated every 15 secs, then we need 60 and 240 historical data for 15mins and 1hr twap
-    Observation[UINT16_MAX + 1] public observations;
+    // if the price is updated every 2 secs, 1hr twap Observation should have 60 / 2 * 60 = 1800 slots
+    Observation[MAX_OBSERVATION + 1] public observations;
 
     //
     // INTERNAL
@@ -54,9 +54,8 @@ contract CumulativeTwap is BlockContext {
             return false;
         }
 
-        // overflow of currentObservationIndex is expected since currentObservationIndex is uint16 (0 - 65535),
-        // so 65535 + 1 will be 0
-        currentObservationIndex++;
+        // ring buffer index, make sure the currentObservationIndex is less than MAX_OBSERVATION
+        currentObservationIndex = (currentObservationIndex + 1) % MAX_OBSERVATION;
 
         uint256 timestampDiff = lastUpdatedTimestamp - lastObservation.timestamp;
         observations[currentObservationIndex] = Observation({
@@ -151,7 +150,7 @@ contract CumulativeTwap is BlockContext {
         }
 
         // now, set before to the oldest observation
-        beforeOrAtIndex = (index + 1);
+        beforeOrAtIndex = (index + 1) % MAX_OBSERVATION;
         if (observations[beforeOrAtIndex].timestamp == 0) {
             beforeOrAtIndex = 0;
         }
@@ -168,14 +167,14 @@ contract CumulativeTwap is BlockContext {
         view
         returns (Observation memory beforeOrAt, Observation memory atOrAfter)
     {
-        uint256 l = currentObservationIndex + 1; // oldest observation
-        uint256 r = l + UINT16_MAX; // newest observation
+        uint256 l = (currentObservationIndex + 1) % MAX_OBSERVATION; // oldest observation
+        uint256 r = l + MAX_OBSERVATION - 1; // newest observation
         uint256 i;
 
         while (true) {
             i = (l + r) / 2;
 
-            beforeOrAt = observations[i % UINT16_MAX];
+            beforeOrAt = observations[i % MAX_OBSERVATION];
 
             // we've landed on an uninitialized observation, keep searching higher (more recently)
             if (beforeOrAt.timestamp == 0) {
@@ -183,7 +182,7 @@ contract CumulativeTwap is BlockContext {
                 continue;
             }
 
-            atOrAfter = observations[(i + 1) % UINT16_MAX];
+            atOrAfter = observations[(i + 1) % MAX_OBSERVATION];
 
             bool targetAtOrAfter = beforeOrAt.timestamp <= targetTimestamp;
 

--- a/contracts/twap/CumulativeTwap.sol
+++ b/contracts/twap/CumulativeTwap.sol
@@ -138,26 +138,22 @@ contract CumulativeTwap is BlockContext {
         view
         returns (Observation memory beforeOrAt, Observation memory atOrAfter)
     {
-        uint16 index = currentObservationIndex;
-        uint16 beforeOrAtIndex = index;
-        uint16 atOrAfterIndex;
+        beforeOrAt = observations[currentObservationIndex];
 
         // if the target is chronologically at or after the newest observation, we can early return
-        if (observations[index].timestamp <= targetTimestamp) {
-            atOrAfterIndex = beforeOrAtIndex;
-
-            return (observations[beforeOrAtIndex], observations[atOrAfterIndex]);
+        if (observations[currentObservationIndex].timestamp <= targetTimestamp) {
+            return (beforeOrAt, beforeOrAt);
         }
 
         // now, set before to the oldest observation
-        beforeOrAtIndex = (index + 1) % MAX_OBSERVATION;
-        if (observations[beforeOrAtIndex].timestamp == 0) {
-            beforeOrAtIndex = 0;
+        beforeOrAt = observations[(currentObservationIndex + 1) % MAX_OBSERVATION];
+        if (beforeOrAt.timestamp == 0) {
+            beforeOrAt = observations[0];
         }
 
         // ensure that the target is chronologically at or after the oldest observation
         // CT_NEH: no enough historical data
-        require(observations[beforeOrAtIndex].timestamp <= targetTimestamp, "CT_NEH");
+        require(beforeOrAt.timestamp <= targetTimestamp, "CT_NEH");
 
         return binarySearch(targetTimestamp);
     }

--- a/contracts/twap/CumulativeTwap.sol
+++ b/contracts/twap/CumulativeTwap.sol
@@ -72,7 +72,7 @@ contract CumulativeTwap is BlockContext {
         uint256 latestUpdatedTimestamp
     ) internal view returns (uint256) {
         // for the first time calculating
-        if (currentObservationIndex == 0 && observations[0].timestamp == 0) {
+        if ((currentObservationIndex == 0 && observations[0].timestamp == 0) || interval == 0) {
             return 0;
         }
 

--- a/contracts/twap/CumulativeTwap.sol
+++ b/contracts/twap/CumulativeTwap.sol
@@ -21,10 +21,11 @@ contract CumulativeTwap is BlockContext {
     // STATE
     //
 
-    uint8 public currentObservationIndex;
+    uint16 public currentObservationIndex;
+    uint16 internal constant UINT16_MAX = 65535;
     // let's use 15 mins and 1 hr twap as example
     // if the price is updated every 15 secs, then we need 60 and 240 historical data for 15mins and 1hr twap
-    Observation[256] public observations;
+    Observation[UINT16_MAX + 1] public observations;
 
     //
     // INTERNAL
@@ -53,8 +54,8 @@ contract CumulativeTwap is BlockContext {
             return false;
         }
 
-        // overflow of currentObservationIndex is expected since currentObservationIndex is uint8 (0 - 255),
-        // so 255 + 1 will be 0
+        // overflow of currentObservationIndex is expected since currentObservationIndex is uint16 (0 - 65535),
+        // so 65535 + 1 will be 0
         currentObservationIndex++;
 
         uint256 timestampDiff = lastUpdatedTimestamp - lastObservation.timestamp;
@@ -133,47 +134,67 @@ contract CumulativeTwap is BlockContext {
         return timestampDiff == 0 ? 0 : currentCumulativePrice.sub(targetCumulativePrice).div(timestampDiff);
     }
 
+    // targetTimestamp = "uniswap's uint32 target = time - secondsAgo"
+    // _blockTimestamp = time
+    // secondsAgo = interval
     function _getSurroundingObservations(uint256 targetTimestamp)
         internal
         view
         returns (Observation memory beforeOrAt, Observation memory atOrAfter)
     {
-        uint8 index = currentObservationIndex;
-        uint8 beforeOrAtIndex;
-        uint8 atOrAfterIndex;
+        uint16 index = currentObservationIndex;
+        uint16 beforeOrAtIndex = index;
+        uint16 atOrAfterIndex;
 
-        // run at most 256 times
-        uint256 observationLen = observations.length;
+        // if the target is chronologically at or after the newest observation, we can early return
+        if (observations[index].timestamp <= targetTimestamp) {
+            atOrAfterIndex = beforeOrAtIndex;
+
+            return (observations[beforeOrAtIndex], observations[atOrAfterIndex]);
+        }
+
+        // now, set before to the oldest observation
+        beforeOrAtIndex = (index + 1);
+        if (observations[beforeOrAtIndex].timestamp == 0) {
+            beforeOrAtIndex = 0;
+        }
+
+        // ensure that the target is chronologically at or after the oldest observation
+        // CT_NEH: no enough historical data
+        require(observations[beforeOrAtIndex].timestamp <= targetTimestamp, "CT_NEH");
+
+        return binarySearch(targetTimestamp);
+    }
+
+    function binarySearch(uint256 targetTimestamp)
+        private
+        view
+        returns (Observation memory beforeOrAt, Observation memory atOrAfter)
+    {
+        uint256 l = currentObservationIndex + 1; // oldest observation
+        uint256 r = l + UINT16_MAX; // newest observation
         uint256 i;
-        for (i = 0; i < observationLen; i++) {
-            if (observations[index].timestamp <= targetTimestamp) {
-                // if the next observation is empty, using the last one
-                // it implies the historical data is not enough
-                if (observations[index].timestamp == 0) {
-                    atOrAfterIndex = beforeOrAtIndex = index + 1;
-                    break;
-                }
-                beforeOrAtIndex = index;
-                atOrAfterIndex = beforeOrAtIndex + 1;
-                break;
+
+        while (true) {
+            i = (l + r) / 2;
+
+            beforeOrAt = observations[i % UINT16_MAX];
+
+            // we've landed on an uninitialized observation, keep searching higher (more recently)
+            if (beforeOrAt.timestamp == 0) {
+                l = i + 1;
+                continue;
             }
-            index--;
-        }
 
-        // not enough historical data to query
-        if (i == observationLen) {
-            // CT_NEH: no enough historical data
-            revert("CT_NEH");
-        }
+            atOrAfter = observations[(i + 1) % UINT16_MAX];
 
-        beforeOrAt = observations[beforeOrAtIndex];
-        atOrAfter = observations[atOrAfterIndex];
+            bool targetAtOrAfter = beforeOrAt.timestamp <= targetTimestamp;
 
-        // if the timestamp of the right bound is earlier than timestamp of the left bound,
-        // either there's only one record, or atOrAfterIndex overflows
-        // in these cases, we set the right bound the same as the left bound.
-        if (atOrAfter.timestamp < beforeOrAt.timestamp) {
-            atOrAfter = beforeOrAt;
+            // check if we've found the answer!
+            if (targetAtOrAfter && targetTimestamp <= atOrAfter.timestamp) break;
+
+            if (!targetAtOrAfter) r = i - 1;
+            else l = i + 1;
         }
     }
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -20,6 +20,9 @@ const config: HardhatUserConfig = {
             },
         },
     },
+    mocha: {
+        timeout: 100000,
+    },
     networks: {
         hardhat: {
             allowUnlimitedContractSize: true,

--- a/test/BandPriceFeed.spec.ts
+++ b/test/BandPriceFeed.spec.ts
@@ -141,8 +141,7 @@ describe("BandPriceFeed/CumulativeTwap Spec", () => {
             })
 
             it("asking interval more than bandReference has", async () => {
-                const price = await bandPriceFeed.getPrice(46)
-                expect(price).to.eq(parseEther("405"))
+                await expect(bandPriceFeed.getPrice(46)).to.be.revertedWith("CT_NEH")
             })
 
             it("asking interval less than bandReference has", async () => {
@@ -192,85 +191,85 @@ describe("BandPriceFeed/CumulativeTwap Spec", () => {
         beforeEach(async () => {
             currentTimeBefore = currentTime = (await waffle.provider.getBlock("latest")).timestamp
 
-            // fill up 255 observations and the final price will be observations[254] = 624,
-            // and observations[255] is empty
-            for (let i = 0; i < 255; i++) {
+            // fill up 1799 observations and the final price will be observations[1798] = 1798 + 400 = 2198,
+            // and observations[1799] is empty
+            for (let i = 0; i < 1799; i++) {
                 await updatePrice(beginPrice + i)
             }
         })
 
         it("verify status", async () => {
-            expect(await bandPriceFeed.currentObservationIndex()).to.eq(254)
+            expect(await bandPriceFeed.currentObservationIndex()).to.eq(1798)
 
-            // observations[255] shouldn't be updated since we only run 255 times in for loop
-            const observation255 = await bandPriceFeed.observations(255)
-            expect(observation255.price).to.eq(0)
-            expect(observation255.priceCumulative).to.eq(0)
-            expect(observation255.timestamp).to.eq(0)
+            // observations[1800] shouldn't be updated since we only run 1800 times in for loop
+            const observation1799 = await bandPriceFeed.observations(1799)
+            expect(observation1799.price).to.eq(0)
+            expect(observation1799.priceCumulative).to.eq(0)
+            expect(observation1799.timestamp).to.eq(0)
 
-            const observation254 = await bandPriceFeed.observations(254)
-            expect(observation254.price).to.eq(parseEther("654"))
-            expect(observation254.timestamp).to.eq(currentTimeBefore + 15 * 254)
+            const observation1798 = await bandPriceFeed.observations(1798)
+            expect(observation1798.price).to.eq(parseEther("2198"))
+            expect(observation1798.timestamp).to.eq(currentTimeBefore + 15 * 1798)
 
-            // (654 * 15 + 653 * 15 + 652 * 15) / 45 = 653
+            // (2196 * 15 + 2197 * 15 + 2198 * 15) / 45 = 2197
             const price = await bandPriceFeed.getPrice(45)
-            expect(price).to.eq(parseEther("653"))
+            expect(price).to.eq(parseEther("2197"))
         })
 
         it("get price after currentObservationIndex is rotated to 0", async () => {
-            // increase currentObservationIndex to 255
-            await updatePrice(beginPrice + 255)
+            // increase currentObservationIndex to 1799
+            await updatePrice(beginPrice + 1799)
 
             // increase (rotate) currentObservationIndex to 0
             // which will override the first observation which is observations[0]
-            await updatePrice(beginPrice + 256)
+            await updatePrice(beginPrice + 1800)
 
             expect(await bandPriceFeed.currentObservationIndex()).to.eq(0)
 
-            // (656 * 15 + 655 * 15 + 654 * 15) / 45 = 655
+            // (2200 * 15 + 2199 * 15 + 2198 * 15) / 45 = 2199
             const price = await bandPriceFeed.getPrice(45)
-            expect(price).to.eq(parseEther("655"))
+            expect(price).to.eq(parseEther("2199"))
         })
 
         it("get price after currentObservationIndex is rotated to 10", async () => {
-            await updatePrice(beginPrice + 255)
+            await updatePrice(beginPrice + 1799)
             for (let i = 0; i < 10; i++) {
-                await updatePrice(beginPrice + 256 + i)
+                await updatePrice(beginPrice + 1800 + i)
             }
 
             expect(await bandPriceFeed.currentObservationIndex()).to.eq(9)
 
-            // (665 * 15 + 664 * 15 + 663 * 15) / 45 = 664
+            // (2207 * 15 + 2208 * 15 + 2209 * 15) / 45 = 2208
             const price = await bandPriceFeed.getPrice(45)
-            expect(price).to.eq(parseEther("664"))
+            expect(price).to.eq(parseEther("2208"))
         })
 
         it("asking interval is exact the same as max allowable interval", async () => {
             // update 2 more times to rotate currentObservationIndex to 0
-            await updatePrice(beginPrice + 255)
+            await updatePrice(beginPrice + 1799)
 
             // this one will override the first observation which is observations[0]
-            await updatePrice(beginPrice + 256, false)
+            await updatePrice(beginPrice + 1800, false)
 
             expect(await bandPriceFeed.currentObservationIndex()).to.eq(0)
 
-            // (((401 + 655) / 2) * 3825 + 656 * 1 ) / 3,826 = 528.0334553058
-            const price = await bandPriceFeed.getPrice(255 * 15 + 1)
-            expect(price).to.eq("528033455305802404600")
+            // (((401 + 2199) / 2) * (26986-1) + 2200 * 1 ) / 26986 = 1300.0333506263
+            const price = await bandPriceFeed.getPrice(1799 * 15 + 1)
+            expect(price).to.eq("1300033350626250648484")
         })
 
         it("force error, asking interval more than observation has", async () => {
             // update 2 more times to rotate currentObservationIndex to 0
-            await updatePrice(beginPrice + 255)
+            await updatePrice(beginPrice + 1799)
 
             // this one will override the first observation which is observations[0]
-            await updatePrice(beginPrice + 256, false)
+            await updatePrice(beginPrice + 1800, false)
 
             expect(await bandPriceFeed.currentObservationIndex()).to.eq(0)
 
-            // the longest interval = 255 * 15 = 3825, it should be revert when interval > 3826
-            // here, we set interval to 3827 because hardhat increases the timestamp by 1 when any tx happens
-            await expect(bandPriceFeed.getPrice(255 * 15 + 2)).to.be.revertedWith("CT_NEH")
+            // the longest interval = 1799 * 15 = 26985, it should be revert when interval >= 26986
+            // here, we set interval to 26987 because hardhat increases the timestamp by 1 when any tx happens
+            await expect(bandPriceFeed.getPrice(1799 * 15 + 2)).to.be.revertedWith("CT_NEH")
         })
     })
 

--- a/test/BandPriceFeed.spec.ts
+++ b/test/BandPriceFeed.spec.ts
@@ -201,7 +201,7 @@ describe("BandPriceFeed/CumulativeTwap Spec", () => {
         it("verify status", async () => {
             expect(await bandPriceFeed.currentObservationIndex()).to.eq(1798)
 
-            // observations[1800] shouldn't be updated since we only run 1800 times in for loop
+            // observations[1799] shouldn't be updated since we only run 1799 times in for loop
             const observation1799 = await bandPriceFeed.observations(1799)
             expect(observation1799.price).to.eq(0)
             expect(observation1799.priceCumulative).to.eq(0)

--- a/test/BandPriceFeed.spec.ts
+++ b/test/BandPriceFeed.spec.ts
@@ -141,7 +141,8 @@ describe("BandPriceFeed/CumulativeTwap Spec", () => {
             })
 
             it("asking interval more than bandReference has", async () => {
-                await expect(bandPriceFeed.getPrice(46)).to.be.revertedWith("CT_NEH")
+                const price = await bandPriceFeed.getPrice(46) // should directly return latest price
+                await expect(price).to.eq(parseEther("410"))
             })
 
             it("asking interval less than bandReference has", async () => {
@@ -258,7 +259,7 @@ describe("BandPriceFeed/CumulativeTwap Spec", () => {
             expect(price).to.eq("1300033350626250648484")
         })
 
-        it("force error, asking interval more than observation has", async () => {
+        it("get the latest price, if asking interval more than observation has", async () => {
             // update 2 more times to rotate currentObservationIndex to 0
             await updatePrice(beginPrice + 1799)
 
@@ -269,7 +270,9 @@ describe("BandPriceFeed/CumulativeTwap Spec", () => {
 
             // the longest interval = 1799 * 15 = 26985, it should be revert when interval >= 26986
             // here, we set interval to 26987 because hardhat increases the timestamp by 1 when any tx happens
-            await expect(bandPriceFeed.getPrice(1799 * 15 + 2)).to.be.revertedWith("CT_NEH")
+            const price = await bandPriceFeed.getPrice(1799 * 15 + 2)
+            const priceWith0Interval = await bandPriceFeed.getPrice(0)
+            await expect(price).to.eq(priceWith0Interval)
         })
     })
 

--- a/test/foundry/ChainlinkPriceFeedV3.t.sol
+++ b/test/foundry/ChainlinkPriceFeedV3.t.sol
@@ -366,7 +366,6 @@ contract ChainlinkPriceFeedV3CacheTwapIntervalIsNotZeroTest is ChainlinkPriceFee
 
         _expect_emit_event_from_ChainlinkPriceFeedV3();
         emit ChainlinkPriceUpdated(_prefilledPrice, _prefilledTimestamp, FreezedReason.IncorrectDecimals);
-        _expect_revert_cacheTwap_CT_IT(_twapInterval);
 
         _getFreezedReason_and_assert_eq(_chainlinkPriceFeedV3, FreezedReason.IncorrectDecimals);
     }
@@ -376,7 +375,6 @@ contract ChainlinkPriceFeedV3CacheTwapIntervalIsNotZeroTest is ChainlinkPriceFee
 
         _expect_emit_event_from_ChainlinkPriceFeedV3();
         emit ChainlinkPriceUpdated(_prefilledPrice, _prefilledTimestamp, FreezedReason.NoRoundId);
-        _expect_revert_cacheTwap_CT_IT(_twapInterval);
         _getFreezedReason_and_assert_eq(_chainlinkPriceFeedV3, FreezedReason.NoRoundId);
     }
 
@@ -386,7 +384,6 @@ contract ChainlinkPriceFeedV3CacheTwapIntervalIsNotZeroTest is ChainlinkPriceFee
 
         _expect_emit_event_from_ChainlinkPriceFeedV3();
         emit ChainlinkPriceUpdated(_prefilledPrice, _prefilledTimestamp, FreezedReason.InvalidTimestamp);
-        _expect_revert_cacheTwap_CT_IT(_twapInterval);
         _getFreezedReason_and_assert_eq(_chainlinkPriceFeedV3, FreezedReason.InvalidTimestamp);
     }
 
@@ -396,7 +393,6 @@ contract ChainlinkPriceFeedV3CacheTwapIntervalIsNotZeroTest is ChainlinkPriceFee
 
         _expect_emit_event_from_ChainlinkPriceFeedV3();
         emit ChainlinkPriceUpdated(_prefilledPrice, _prefilledTimestamp, FreezedReason.InvalidTimestamp);
-        _expect_revert_cacheTwap_CT_IT(_twapInterval);
 
         _getFreezedReason_and_assert_eq(_chainlinkPriceFeedV3, FreezedReason.InvalidTimestamp);
     }
@@ -418,7 +414,6 @@ contract ChainlinkPriceFeedV3CacheTwapIntervalIsNotZeroTest is ChainlinkPriceFee
 
         _expect_emit_event_from_ChainlinkPriceFeedV3();
         emit ChainlinkPriceUpdated(_prefilledPrice, _prefilledTimestamp, FreezedReason.NonPositiveAnswer);
-        _expect_revert_cacheTwap_CT_IT(_twapInterval);
         _getFreezedReason_and_assert_eq(_chainlinkPriceFeedV3, FreezedReason.NonPositiveAnswer);
     }
 }

--- a/test/foundry/ChainlinkPriceFeedV3.t.sol
+++ b/test/foundry/ChainlinkPriceFeedV3.t.sol
@@ -16,6 +16,7 @@ contract ChainlinkPriceFeedV3ConstructorTest is Setup {
 }
 
 contract ChainlinkPriceFeedV3Common is IChainlinkPriceFeedV3Event, Setup {
+    using stdStorage for StdStorage;
     uint24 internal constant _ONE_HUNDRED_PERCENT_RATIO = 1e6;
     uint256 internal _timestamp = 10000000;
     uint256 internal _price = 1000 * 1e8;

--- a/test/foundry/ChainlinkPriceFeedV3.t.sol
+++ b/test/foundry/ChainlinkPriceFeedV3.t.sol
@@ -157,6 +157,7 @@ contract ChainlinkPriceFeedV3CacheTwapIntervalIsZeroTest is ChainlinkPriceFeedV3
     }
 
     function test_cacheTwap_wont_update_when_the_new_timestamp_is_the_same() public {
+        _chainlinkPriceFeedV3_prefill_observation_to_make_twap_calculatable();
         _chainlinkPriceFeedV3.cacheTwap(0);
 
         uint256 t2 = _timestamp + 60;
@@ -321,8 +322,6 @@ contract ChainlinkPriceFeedV3CacheTwapIntervalIsNotZeroTest is ChainlinkPriceFee
     }
 
     function test_cacheTwap_wont_update_when_the_new_timestamp_is_the_same() public {
-        _chainlinkPriceFeedV3_cacheTwap_and_assert_eq(_twapInterval, _price);
-
         uint256 t2 = _timestamp + 60;
 
         _mock_call_latestRoundData(_roundId, 2000 * 1e8, t2);
@@ -366,7 +365,7 @@ contract ChainlinkPriceFeedV3CacheTwapIntervalIsNotZeroTest is ChainlinkPriceFee
 
         _expect_emit_event_from_ChainlinkPriceFeedV3();
         emit ChainlinkPriceUpdated(_prefilledPrice, _prefilledTimestamp, FreezedReason.IncorrectDecimals);
-
+        _chainlinkPriceFeedV3.cacheTwap(_twapInterval);
         _getFreezedReason_and_assert_eq(_chainlinkPriceFeedV3, FreezedReason.IncorrectDecimals);
     }
 
@@ -375,6 +374,7 @@ contract ChainlinkPriceFeedV3CacheTwapIntervalIsNotZeroTest is ChainlinkPriceFee
 
         _expect_emit_event_from_ChainlinkPriceFeedV3();
         emit ChainlinkPriceUpdated(_prefilledPrice, _prefilledTimestamp, FreezedReason.NoRoundId);
+        _chainlinkPriceFeedV3.cacheTwap(_twapInterval);
         _getFreezedReason_and_assert_eq(_chainlinkPriceFeedV3, FreezedReason.NoRoundId);
     }
 
@@ -384,6 +384,7 @@ contract ChainlinkPriceFeedV3CacheTwapIntervalIsNotZeroTest is ChainlinkPriceFee
 
         _expect_emit_event_from_ChainlinkPriceFeedV3();
         emit ChainlinkPriceUpdated(_prefilledPrice, _prefilledTimestamp, FreezedReason.InvalidTimestamp);
+        _chainlinkPriceFeedV3.cacheTwap(_twapInterval);
         _getFreezedReason_and_assert_eq(_chainlinkPriceFeedV3, FreezedReason.InvalidTimestamp);
     }
 
@@ -393,7 +394,7 @@ contract ChainlinkPriceFeedV3CacheTwapIntervalIsNotZeroTest is ChainlinkPriceFee
 
         _expect_emit_event_from_ChainlinkPriceFeedV3();
         emit ChainlinkPriceUpdated(_prefilledPrice, _prefilledTimestamp, FreezedReason.InvalidTimestamp);
-
+        _chainlinkPriceFeedV3.cacheTwap(_twapInterval);
         _getFreezedReason_and_assert_eq(_chainlinkPriceFeedV3, FreezedReason.InvalidTimestamp);
     }
 
@@ -414,6 +415,8 @@ contract ChainlinkPriceFeedV3CacheTwapIntervalIsNotZeroTest is ChainlinkPriceFee
 
         _expect_emit_event_from_ChainlinkPriceFeedV3();
         emit ChainlinkPriceUpdated(_prefilledPrice, _prefilledTimestamp, FreezedReason.NonPositiveAnswer);
+        _chainlinkPriceFeedV3.cacheTwap(_twapInterval);
+
         _getFreezedReason_and_assert_eq(_chainlinkPriceFeedV3, FreezedReason.NonPositiveAnswer);
     }
 }

--- a/test/foundry/ChainlinkPriceFeedV3.t.sol
+++ b/test/foundry/ChainlinkPriceFeedV3.t.sol
@@ -286,9 +286,8 @@ contract ChainlinkPriceFeedV3CacheTwapIntervalIsNotZeroTest is ChainlinkPriceFee
         // make sure that even if there's no cache observation, CumulativeTwap won't calculate a TWAP
         vm.warp(_timestamp + 1);
 
-        // FIXME: imprecise calculation
-        // (995 * 1800 + 1000 * 1) / 1801 = 995.00277623
-        assertEq(_chainlinkPriceFeedV3.getCachedTwap(_twapInterval), 995.00277623 * 1e8);
+        // (995 * 1799 + 1000 * 1) / 1800 = 995.00277777
+        assertEq(_chainlinkPriceFeedV3.getCachedTwap(_twapInterval), 995.00277777 * 1e8);
     }
 
     function test_getCachedTwap_with_valid_price_after_a_second() public {


### PR DESCRIPTION
* Observation extends to 1800
  * Binary search copied from https://github.com/Uniswap/v3-core/blob/05c10bf/contracts/libraries/Oracle.sol#L153
* Fix imprecise TWAP caluclation in some conditions (https://github.com/perpetual-protocol/perp-oracle-contract/pull/63)
* Remove `CT_NEH`. when historical data is not enough, simply return latest price


TODO

- [x] migrate `BandPriceFeed.spec` to `CumulativeTwap.t.sol`