### PR TITLE
upgrade GitHub workflow for new syntax

### DIFF
--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -24,7 +24,7 @@ jobs:
             - name: Get npm cache directory
               id: npm-cache
               run: |
-                  echo "::set-output name=dir::$(npm config get cache)"
+                  echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
             - uses: actions/cache@v2
               with:
                   path: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,7 +20,7 @@ jobs:
             - name: Get npm cache directory
               id: npm-cache
               run: |
-                  echo "::set-output name=dir::$(npm config get cache)"
+                  echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
             - uses: actions/cache@v2
               with:
                   path: |
@@ -59,7 +59,7 @@ jobs:
           - name: Get npm cache directory
             id: npm-cache
             run: |
-              echo "::set-output name=dir::$(npm config get cache)"
+              echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
           - uses: actions/cache@v2
             with:
               path: |
@@ -101,7 +101,7 @@ jobs:
             - name: Get npm cache directory
               id: npm-cache
               run: |
-                  echo "::set-output name=dir::$(npm config get cache)"
+                  echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
             - uses: actions/cache@v2
               with:
                   path: |


### PR DESCRIPTION
because `set-output` has been deprecated
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204547419615978